### PR TITLE
feat: align hash_4 signature; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ A TypeScript implementation of Poseidon2 compression over the BN254 field suppor
 
 ## Library API
 
-- `hash_1(x: bigint) -> bigint`
-- `hash_2(x: bigint, y: bigint) -> bigint`
+- `hash_1(a: bigint) -> bigint`
+- `hash_2(a: bigint, b: bigint) -> bigint`
 - `hash_3(a: bigint, b: bigint, c: bigint) -> bigint`
-- `hash_4([a, b, c, d]: [bigint, bigint, bigint, bigint]) -> bigint`
+- `hash_4(a: bigint, b: bigint, c: bigint, d: bigint) -> bigint`
+
+## Compatibility
+
+- Follows: This library follows [TaceoLabs/noir-poseidon Poseidon2](https://github.com/TaceoLabs/noir-poseidon/tree/main/poseidon2) parameters and outputs for drop‑in compatibility.
+- Permutations: t=2 and t=3 are implemented locally; t=4 delegates to `@zkpassport/poseidon2@0.6.2`.
+- Tests: Test vectors are taken from upstream to verify bit‑for‑bit equality.
 
 ## Development
 ```bash
@@ -27,10 +33,8 @@ bun x vitest run
 bun run build
 ```
 
-Notes:
-- t=2 and t=3 permutations are implemented locally; t=4 uses `@zkpassport/poseidon2`.
-
 ## Reference
 - [Poseidon2: A Faster Version of the Poseidon Hash Function](https://eprint.iacr.org/2023/323)
-- [TaceoLabs noir-poseidon](https://github.com/TaceoLabs/noir-poseidon)
-- [HorizonLabs poseidon2](https://github.com/HorizenLabs/poseidon2)
+- [TaceoLabs/noir-poseidon](https://github.com/TaceoLabs/noir-poseidon)
+- [HorizenLabs/poseidon2](https://github.com/HorizenLabs/poseidon2)
+- [zkpassport/poseidon2](https://github.com/zkpassport/poseidon2)

--- a/src/hash_4.ts
+++ b/src/hash_4.ts
@@ -1,12 +1,10 @@
 import { permute as permuteBn254T4 } from "@zkpassport/poseidon2"
 
+export function hash_4(a: bigint, b: bigint, c: bigint, d: bigint): bigint {
+  return permute_4([a, b, c, d])[0]
+}
+
 export function permute_4(input: [bigint, bigint, bigint, bigint]): [bigint, bigint, bigint, bigint] {
   const out = permuteBn254T4(input)
   return [out[0]!, out[1]!, out[2]!, out[3]!]
 }
-
-export function hash_4(input: [bigint,bigint,bigint,bigint]): bigint {
-  return permute_4(input)[0]
-}
-
-

--- a/src/permutations/poseidon2_permutation.ts
+++ b/src/permutations/poseidon2_permutation.ts
@@ -1,4 +1,4 @@
-import { add, mod, sbox, sbox_e } from "../utils/arith"
+import { add, sbox, sbox_e } from "../utils/arith"
 
 export type Poseidon2Cfg<T extends bigint[]> = {
   first_full_rc: T[]


### PR DESCRIPTION
- `hash_4([a,b,c,d])` → `hash_4(a,b,c,d)`
- README: update API, add “Compatibility” (follows noir-poseidon/poseidon2), add `@zkpassport/poseidon2` to references