### PR TITLE
fix: typescript fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,10 +10,8 @@
         "@types/bun": "1.2.20",
         "@types/node": "24.2.1",
         "tsup": "8.5.0",
+        "typescript": "^5.9.3",
         "vitest": "3.2.4",
-      },
-      "peerDependencies": {
-        "typescript": ">=5.9.2 <6",
       },
     },
   },
@@ -336,7 +334,7 @@
 
     "tsup": ["tsup@8.5.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
     "@types/bun": "1.2.20",
     "@types/node": "24.2.1",
     "tsup": "8.5.0",
+    "typescript": "^5.9.3",
     "vitest": "3.2.4"
-  },
-  "peerDependencies": {
-    "typescript": ">=5.9.2 <6"
   },
   "dependencies": {
     "@zkpassport/poseidon2": "0.6.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "build": "tsup index.ts --format esm,cjs --dts --out-dir dist --clean",
-    "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "merkle:zeros": "tsup scripts/merkle_zeros.ts --format esm --out-dir scripts && bun ./scripts/merkle_zeros"


### PR DESCRIPTION
This PR fixes two problems we had.

The first one is that TypeScript was a peer dependency, but usually it's installed as a dev dependency as other package managers might have issues finding it.

I also removed the `prepare` script which will trigger the `build` script when the package is installed. IMHO it's not necessary to build the project as the `dist` directory is already part of the project and tracked via git. Removing this fixes the problem of Yarn not being able to install the package properly.